### PR TITLE
feat: Update peer-did creation and resolution inline with …

### DIFF
--- a/didpeer/README.md
+++ b/didpeer/README.md
@@ -130,10 +130,10 @@ Example of DID documents:
     "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
     "authentication": [
         {
-            "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+            "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#",
             "type": "Ed25519VerificationKey2020",
             "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-            "publicKeyMultibase": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
+            "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
         }
     ]
 }
@@ -141,42 +141,141 @@ Example of DID documents:
 ### did_doc_algo_2
 ```json
 {
-   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
-   "authentication": [
-       {
-           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
-           "type": "Ed25519VerificationKey2020",
-           "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
-           "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
-       },
-       {
-           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
-           "type": "Ed25519VerificationKey2020",
-           "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
-           "publicKeyMultibase": "z6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
-       }
-   ],
-   "keyAgreement": [
-       {
-           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
-           "type": "X25519KeyAgreementKey2020",
-           "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
-           "publicKeyMultibase": "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
-       }
-   ],
-   "service": [
-       {
-           "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#didcommmessaging-0",
-           "type": "DIDCommMessaging",
-           "serviceEndpoint": "https://example.com/endpoint",
-           "routingKeys": [
-               "did:example:somemediator#somekey"
-           ],
-           "accept": [
-                "didcomm/v2", "didcomm/aip2;env=rfc587"
-           ]
-       }
-   ]
+  "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
+  "authentication": [
+    {
+      "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19#key-2",
+      "type": "Ed25519VerificationKey2020",
+      "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
+      "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+    }
+  ],
+  "keyAgreement": [
+    {
+      "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19#key-1",
+      "type": "X25519KeyAgreementKey2020",
+      "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
+      "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
+    }
+  ],
+  "service": [
+    {
+      "id": "#service",
+      "type": "DIDCommMessaging",
+      "serviceEndpoint": {
+        "uri": "https://example.com/endpoint1",
+        "routingKeys": [
+          "did:example:somemediator#somekey1"
+        ],
+        "accept": [
+          "didcomm/v2", "didcomm/aip2;env=rfc587"
+        ]
+      }
+    }
+  ]
+}
+```
+
+### Example code based the new PeerDID Spec https://identity.foundation/peer-did-method-spec/
+
+```kotlin
+val encryptionKeys = listOf(
+    VerificationMaterialAgreement(
+        type = VerificationMethodTypeAgreement.X25519_KEY_AGREEMENT_KEY_2019,
+        format = VerificationMaterialFormatPeerDID.BASE58,
+        value = "DmgBSHMqaZiYqwNMEJJuxWzsGGC8jUYADrfSdBrC6L8s",
+    )
+)
+val signingKeys = listOf(
+    VerificationMaterialAuthentication(
+        type = VerificationMethodTypeAuthentication.ED25519_VERIFICATION_KEY_2018,
+        format = VerificationMaterialFormatPeerDID.BASE58,
+        value = "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7",
+    )
+)
+val service =
+"""
+    {
+      "type": "DIDCommMessaging",
+      "serviceEndpoint": {
+        "uri": "https://example.com/endpoint1",
+        "routingKeys": [
+          "did:example:somemediator#somekey1"
+        ],
+        "accept": [
+          "didcomm/v2",
+          "didcomm/aip2;env=rfc587"
+        ]
+      }
+    }
+"""
+
+val peerDIDAlgo0 = createPeerDIDNumalgo0(signingKeys[0])
+val peerDIDAlgo2 = createPeerDIDNumalgo2(
+  encryptionKeys, signingKeys, service
+)
+
+val didDocAlgo0Json = resolvePeerDID(peerDIDAlgo0)
+val didDocAlgo2Json = resolvePeerDID(peerDIDAlgo2)
+
+val didDocAlgo0 = DIDDocPeerDID.fromJson(didDocAlgo0Json)
+val didDocAlgo2 = DIDDocPeerDID.fromJson(didDocAlgo2Json)
+```
+
+### Example of DID Documents:
+
+#### DIDDoc algo 0:
+
+```json
+{
+    "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+    "authentication": [
+        {
+          "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#key-1",
+          "type": "Ed25519VerificationKey2020",
+          "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+          "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+        }
+    ]
+}
+```
+
+##### did_doc_algo_2
+
+```json
+{
+    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
+    "authentication": [
+        {
+            "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19#key-2",
+            "type": "Ed25519VerificationKey2020",
+            "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
+            "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+        }
+    ],
+    "keyAgreement": [
+        {
+            "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19#key-1",
+            "type": "X25519KeyAgreementKey2020",
+            "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
+            "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
+        }
+    ],
+    "service": [
+        {
+            "id": "#service",
+            "type": "DIDCommMessaging",
+            "serviceEndpoint": {
+                "uri": "https://example.com/endpoint1",
+                "routingKeys": [
+                    "did:example:somemediator#somekey1"
+                ],
+                "accept": [
+                    "didcomm/v2", "didcomm/aip2;env=rfc587"
+                ]
+            }
+        }
+    ]
 }
 ```
 

--- a/didpeer/src/commonMain/kotlin/io/iohk/atala/prism/didcomm/didpeer/DIDDoc.kt
+++ b/didpeer/src/commonMain/kotlin/io/iohk/atala/prism/didcomm/didpeer/DIDDoc.kt
@@ -13,6 +13,7 @@ const val SERVICE_ENDPOINT = "serviceEndpoint"
 const val SERVICE_DIDCOMM_MESSAGING = "DIDCommMessaging"
 const val SERVICE_ROUTING_KEYS = "routingKeys"
 const val SERVICE_ACCEPT = "accept"
+const val SERVICE_URI = "uri"
 
 /**
  * Represents a PeerDID DID Document.
@@ -147,6 +148,19 @@ data class VerificationMethodPeerDID(
 sealed interface Service
 
 /**
+ * Represents a service endpoint.
+ *
+ * @property uri The URI of the endpoint.
+ * @property routingKeys The list of routing keys associated with the endpoint.
+ * @property accept The list of accepted content types for the endpoint.
+ */
+data class ServiceEndpoint(
+    val uri: String,
+    val routingKeys: List<String>,
+    val accept: List<String>
+)
+
+/**
  * Represents a service provided by a DID document.
  *
  * @property data The data of the service.
@@ -158,31 +172,27 @@ data class OtherService(val data: Map<String, Any>) : Service
  * @property id The ID of the service.
  * @property type The type of the service.
  * @property serviceEndpoint The service endpoint.
- * @property routingKeys The list of routing keys.
- * @property accept The list of accepted message types.
  */
 data class DIDCommServicePeerDID(
     val id: String,
     val type: String,
-    val serviceEndpoint: String,
-    val routingKeys: List<String>,
-    val accept: List<String>
+    val serviceEndpoint: ServiceEndpoint
 ) : Service {
     /**
      * Converts the DIDCommServicePeerDID object to a mutable map representation.
      *
      * @return The mutable map representation of the DIDCommServicePeerDID object.
      */
-    fun toDict(): MutableMap<String, Any> {
-        val res =
-            mutableMapOf<String, Any>(
-                SERVICE_ID to id,
-                SERVICE_TYPE to type
+    fun toDict(): Map<String, Any> {
+        return mapOf(
+            SERVICE_ID to id,
+            SERVICE_TYPE to type,
+            SERVICE_ENDPOINT to mapOf(
+                SERVICE_URI to serviceEndpoint.uri,
+                SERVICE_ROUTING_KEYS to serviceEndpoint.routingKeys,
+                SERVICE_ACCEPT to serviceEndpoint.accept
             )
-        res[SERVICE_ENDPOINT] = serviceEndpoint
-        res[SERVICE_ROUTING_KEYS] = routingKeys
-        res[SERVICE_ACCEPT] = accept
-        return res
+        )
     }
 }
 

--- a/didpeer/src/commonMain/kotlin/io/iohk/atala/prism/didcomm/didpeer/PeerDIDResolver.kt
+++ b/didpeer/src/commonMain/kotlin/io/iohk/atala/prism/didcomm/didpeer/PeerDIDResolver.kt
@@ -50,7 +50,7 @@ private fun buildDIDDocNumalgo0(peerDID: PeerDID, format: VerificationMaterialFo
     val decodedEncumbasis = decodeMultibaseEncnumbasisAuth(inceptionKey, format)
     return DIDDocPeerDID(
         did = peerDID,
-        authentication = listOf(getVerificationMethod(peerDID, decodedEncumbasis))
+        authentication = listOf(getVerificationMethod(1, peerDID, decodedEncumbasis))
     )
 }
 
@@ -66,14 +66,13 @@ private fun buildDIDDocNumalgo0(peerDID: PeerDID, format: VerificationMaterialFo
 private fun buildDIDDocNumalgo2(peerDID: PeerDID, format: VerificationMaterialFormatPeerDID): DIDDocPeerDID {
     val keys = peerDID.drop(11)
 
-    var service = ""
     val encodedServicesJson = mutableListOf<JSON>()
     val authentications = mutableListOf<VerificationMethodPeerDID>()
     val keyAgreement = mutableListOf<VerificationMethodPeerDID>()
 
-    keys.split(".").forEach {
-        val prefix = it[0]
-        val value = it.drop(1)
+    keys.split(".").withIndex().forEach { (index, keyIt) ->
+        val prefix = keyIt[0]
+        val value = keyIt.drop(1)
 
         when (prefix) {
             Numalgo2Prefix.SERVICE.prefix -> {
@@ -82,12 +81,12 @@ private fun buildDIDDocNumalgo2(peerDID: PeerDID, format: VerificationMaterialFo
 
             Numalgo2Prefix.AUTHENTICATION.prefix -> {
                 val decodedEncumbasis = decodeMultibaseEncnumbasisAuth(value, format)
-                authentications.add(getVerificationMethod(peerDID, decodedEncumbasis))
+                authentications.add(getVerificationMethod(index + 1, peerDID, decodedEncumbasis))
             }
 
             Numalgo2Prefix.KEY_AGREEMENT.prefix -> {
                 val decodedEncumbasis = decodeMultibaseEncnumbasisAgreement(value, format)
-                keyAgreement.add(getVerificationMethod(peerDID, decodedEncumbasis))
+                keyAgreement.add(getVerificationMethod(index + 1, peerDID, decodedEncumbasis))
             }
 
             else -> throw IllegalArgumentException("Unsupported transform part of PeerDID: $prefix")

--- a/didpeer/src/commonMain/kotlin/io/iohk/atala/prism/didcomm/didpeer/core/DIDDocHelper.kt
+++ b/didpeer/src/commonMain/kotlin/io/iohk/atala/prism/didcomm/didpeer/core/DIDDocHelper.kt
@@ -4,13 +4,12 @@ import io.iohk.atala.prism.didcomm.didpeer.DIDCommServicePeerDID
 import io.iohk.atala.prism.didcomm.didpeer.DIDDocPeerDID
 import io.iohk.atala.prism.didcomm.didpeer.OtherService
 import io.iohk.atala.prism.didcomm.didpeer.PublicKeyField
-import io.iohk.atala.prism.didcomm.didpeer.SERVICE_ACCEPT
 import io.iohk.atala.prism.didcomm.didpeer.SERVICE_DIDCOMM_MESSAGING
 import io.iohk.atala.prism.didcomm.didpeer.SERVICE_ENDPOINT
 import io.iohk.atala.prism.didcomm.didpeer.SERVICE_ID
-import io.iohk.atala.prism.didcomm.didpeer.SERVICE_ROUTING_KEYS
 import io.iohk.atala.prism.didcomm.didpeer.SERVICE_TYPE
 import io.iohk.atala.prism.didcomm.didpeer.Service
+import io.iohk.atala.prism.didcomm.didpeer.ServiceEndpoint
 import io.iohk.atala.prism.didcomm.didpeer.VerificationMaterialFormatPeerDID
 import io.iohk.atala.prism.didcomm.didpeer.VerificationMaterialPeerDID
 import io.iohk.atala.prism.didcomm.didpeer.VerificationMethodPeerDID
@@ -151,16 +150,21 @@ internal fun serviceFromJson(jsonObject: JsonObject): Service {
         return OtherService(serviceMap)
     }
 
-    val endpoint = jsonObject[SERVICE_ENDPOINT]?.jsonPrimitive?.content
-    val routingKeys = jsonObject[SERVICE_ROUTING_KEYS]?.jsonArray?.map { it.jsonPrimitive.content }
-    val accept = jsonObject[SERVICE_ACCEPT]?.jsonArray?.map { it.jsonPrimitive.content }
+    val serviceEndpointObject = jsonObject[SERVICE_ENDPOINT]?.jsonObject
+    val uri = serviceEndpointObject?.get("uri")?.jsonPrimitive?.content ?: ""
+    val routingKeys = serviceEndpointObject?.get("routingKeys")?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
+    val accept = serviceEndpointObject?.get("accept")?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
+
+    val serviceEndpoint = ServiceEndpoint(
+        uri = uri,
+        routingKeys = routingKeys,
+        accept = accept
+    )
 
     return DIDCommServicePeerDID(
         id = id,
         type = type,
-        serviceEndpoint = endpoint ?: "",
-        routingKeys = routingKeys ?: emptyList(),
-        accept = accept ?: emptyList()
+        serviceEndpoint = serviceEndpoint
     )
 }
 

--- a/didpeer/src/commonMain/kotlin/io/iohk/atala/prism/didcomm/didpeer/core/Utils.kt
+++ b/didpeer/src/commonMain/kotlin/io/iohk/atala/prism/didcomm/didpeer/core/Utils.kt
@@ -99,6 +99,8 @@ private fun extractFromJsonObject(jsonObject: JsonObject): Map<String, Any> {
                 }
             }
             currentMap[it.key] = localArray
+        } else if (it.value is JsonObject) {
+            currentMap[it.key] = extractFromJsonObject(it.value as JsonObject)
         } else {
             throw Exception("")
         }

--- a/didpeer/src/commonTest/kotlin/io/iohk/atala/prism/didcomm/didpeer/Fixture.kt
+++ b/didpeer/src/commonTest/kotlin/io/iohk/atala/prism/didcomm/didpeer/Fixture.kt
@@ -19,7 +19,7 @@ const val DID_DOC_NUMALGO_O_BASE58 = """
            "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
            "authentication": [
                {
-                   "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#key-1",
                    "type": "Ed25519VerificationKey2018",
                    "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                    "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
@@ -33,7 +33,7 @@ const val DID_DOC_NUMALGO_O_MULTIBASE = """
            "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
            "authentication": [
                {
-                   "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#key-1",
                    "type": "Ed25519VerificationKey2020",
                    "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                    "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
@@ -47,7 +47,7 @@ const val DID_DOC_NUMALGO_O_JWK = """
             "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
             "authentication": [
                 {
-                    "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                    "id": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#key-1",
                     "type": "JsonWebKey2020",
                     "controller": "did:peer:0z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                     "publicKeyJwk": {
@@ -73,13 +73,13 @@ const val DID_DOC_NUMALGO_2_BASE58 = """
            "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
            "authentication": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-2",
                    "type": "Ed25519VerificationKey2018",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                    "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
                },
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-3",
                    "type": "Ed25519VerificationKey2018",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                    "publicKeyBase58": "3M5RCDjPTWPkKSN3sxUmmMqHbmRPegYP1tjcKyrDbt9J"
@@ -87,7 +87,7 @@ const val DID_DOC_NUMALGO_2_BASE58 = """
            ],
            "keyAgreement": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-1",
                    "type": "X25519KeyAgreementKey2019",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                    "publicKeyBase58": "JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"
@@ -95,15 +95,15 @@ const val DID_DOC_NUMALGO_2_BASE58 = """
            ],
            "service": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#didcommmessaging-0",
-                   "type": "DIDCommMessaging",
-                   "serviceEndpoint": "https://example.com/endpoint",
-                   "routingKeys": [
-                       "did:example:somemediator#somekey"
-                   ],
-                   "accept": [
-                        "didcomm/v2", "didcomm/aip2;env=rfc587"
-                   ]
+                   "id": "#service",
+                    "type": "DIDCommMessaging",
+                    "serviceEndpoint": { 
+                        "uri": "https://example.com/endpoint",
+                        "routingKeys": [
+                            "did:example:somemediator#somekey"
+                        ],
+                        "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+                   }
                }
            ]
        }
@@ -114,13 +114,13 @@ const val DID_DOC_NUMALGO_2_MULTIBASE = """
            "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
            "authentication": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-2",
                    "type": "Ed25519VerificationKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                    "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
                },
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-3",
                    "type": "Ed25519VerificationKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                    "publicKeyMultibase": "z6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
@@ -128,7 +128,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE = """
            ],
            "keyAgreement": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-1",
                    "type": "X25519KeyAgreementKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                    "publicKeyMultibase": "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
@@ -136,15 +136,15 @@ const val DID_DOC_NUMALGO_2_MULTIBASE = """
            ],
            "service": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#didcommmessaging-0",
+                   "id": "#service",
                    "type": "DIDCommMessaging",
-                   "serviceEndpoint": "https://example.com/endpoint",
-                   "routingKeys": [
-                       "did:example:somemediator#somekey"
-                   ],
-                   "accept": [
-                        "didcomm/v2", "didcomm/aip2;env=rfc587"
-                   ]
+                   "serviceEndpoint": { 
+                        "uri": "https://example.com/endpoint",
+                        "routingKeys": [
+                            "did:example:somemediator#somekey"
+                        ],
+                        "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+                   }
                }
            ]
        }
@@ -155,7 +155,7 @@ const val DID_DOC_NUMALGO_2_JWK = """
            "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
            "authentication": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-2",
                    "type": "JsonWebKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                     "publicKeyJwk": {
@@ -165,7 +165,7 @@ const val DID_DOC_NUMALGO_2_JWK = """
                      }
                },
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-3",
                    "type": "JsonWebKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                     "publicKeyJwk": {
@@ -177,7 +177,7 @@ const val DID_DOC_NUMALGO_2_JWK = """
            ],
            "keyAgreement": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#key-1",
                    "type": "JsonWebKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
                     "publicKeyJwk": {
@@ -189,15 +189,15 @@ const val DID_DOC_NUMALGO_2_JWK = """
            ],
            "service": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#didcommmessaging-0",
-                   "type": "DIDCommMessaging",
-                   "serviceEndpoint": "https://example.com/endpoint",
-                   "routingKeys": [
-                       "did:example:somemediator#somekey"
-                   ],
-                   "accept": [
-                        "didcomm/v2", "didcomm/aip2;env=rfc587"
-                   ]
+                   "id": "#service",
+                    "type": "DIDCommMessaging",
+                    "serviceEndpoint": { 
+                        "uri": "https://example.com/endpoint",
+                        "routingKeys": [
+                            "did:example:somemediator#somekey"
+                        ],
+                        "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+                   } 
                }
            ]
        }
@@ -215,7 +215,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES = """
             "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0",
             "authentication": [
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#key-2",
                     "type": "Ed25519VerificationKey2020",
                     "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0",
                     "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
@@ -223,7 +223,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES = """
             ],
             "keyAgreement": [
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#key-1",
                     "type": "X25519KeyAgreementKey2020",
                     "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0",
                     "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
@@ -231,40 +231,44 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES = """
             ],
             "service": [
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#didcommmessaging-0",
+                    "id": "#service",
                     "type": "DIDCommMessaging",
-                    "serviceEndpoint": "https://example.com/endpoint",
-                    "routingKeys": [
-                        "did:example:somemediator#somekey"
-                    ]
+                    "serviceEndpoint": {
+                        "uri": "https://example.com/endpoint",
+                        "routingKeys": [
+                            "did:example:somemediator#somekey"
+                        ]
+                    }
                 },
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#example-1",
+                    "id": "#service-1",
                     "type": "example",
-                    "serviceEndpoint": "https://example.com/endpoint2",
-                    "routingKeys": [
-                        "did:example:somemediator#somekey2"
-                    ],
-                    "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+                    "serviceEndpoint": { 
+                        "uri": "https://example.com/endpoint2",
+                        "routingKeys": [
+                            "did:example:somemediator#somekey2"
+                        ],
+                        "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+                   } 
                 }
             ]
         }
     """
 
 const val PEER_DID_NUMALGO_2_2_ENCODED_SERVICES_INDIVIDUALLY = (
-        "did:peer:2" +
-                ".Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud" +
-                ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V" +
-                ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K" +
-                ".SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19"
-        )
+    "did:peer:2" +
+        ".Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud" +
+        ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V" +
+        ".SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K" +
+        ".SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19"
+    )
 
 const val DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES_INDIVIDUALLY = """
         {
           "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19",
           "authentication": [
             {
-              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#key-2",
               "type": "Ed25519VerificationKey2020",
               "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19",
               "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
@@ -272,7 +276,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES_INDIVIDUALLY = """
           ],
           "keyAgreement": [
             {
-              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
+              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#key-1",
               "type": "X25519KeyAgreementKey2020",
               "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19",
               "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
@@ -280,24 +284,25 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_2_SERVICES_INDIVIDUALLY = """
           ],
           "service": [
             {
-              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#didcommmessaging-0",
-              "type": "DIDCommMessaging",
-              "serviceEndpoint": "https://example.com/endpoint",
-              "routingKeys": [
-                "did:example:somemediator#somekey"
-              ]
+              "id": "#service",
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": {
+                    "uri": "https://example.com/endpoint",
+                    "routingKeys": [
+                    "did:example:somemediator#somekey"
+                    ]
+                }
             },
             {
-              "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXX0K.SeyJ0IjoiZXhhbXBsZSIsInMiOiJodHRwczovL2V4YW1wbGUuY29tL2VuZHBvaW50MiIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkyIl0sImEiOlsiZGlkY29tbS92MiIsImRpZGNvbW0vYWlwMjtlbnY9cmZjNTg3Il19#example-1",
-              "type": "example",
-              "serviceEndpoint": "https://example.com/endpoint2",
-              "routingKeys": [
-                "did:example:somemediator#somekey2"
-              ],
-              "accept": [
-                "didcomm/v2",
-                "didcomm/aip2;env=rfc587"
-              ]
+              "id": "#service-1",
+                "type": "example",
+                "serviceEndpoint": { 
+                    "uri": "https://example.com/endpoint2",
+                    "routingKeys": [
+                        "did:example:somemediator#somekey2"
+                    ],
+                    "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+               }
             }
           ]
         }
@@ -314,7 +319,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_NO_SERVICES = """
             "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
             "authentication": [
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#key-2",
                     "type": "Ed25519VerificationKey2020",
                     "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                     "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
@@ -322,7 +327,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_NO_SERVICES = """
             ],
             "keyAgreement": [
                 {
-                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
+                    "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V#key-1",
                     "type": "X25519KeyAgreementKey2020",
                     "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
                     "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
@@ -331,20 +336,21 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_NO_SERVICES = """
         }
     """
 
-const val PEER_DID_NUMALGO_2_MINIMAL_SERVICES = "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9"
+const val PEER_DID_NUMALGO_2_MINIMAL_SERVICES =
+    "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9"
 
 const val DID_DOC_NUMALGO_2_MULTIBASE_MINIMAL_SERVICES = """
         {
            "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9",
            "authentication": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#key-2",
                    "type": "Ed25519VerificationKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9",
                    "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
                },
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#key-3",
                    "type": "Ed25519VerificationKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9",
                    "publicKeyMultibase": "z6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg"
@@ -352,7 +358,7 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_MINIMAL_SERVICES = """
            ],
            "keyAgreement": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#key-1",
                    "type": "X25519KeyAgreementKey2020",
                    "controller": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9",
                    "publicKeyMultibase": "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
@@ -360,9 +366,11 @@ const val DID_DOC_NUMALGO_2_MULTIBASE_MINIMAL_SERVICES = """
            ],
            "service": [
                {
-                   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#didcommmessaging-0",
-                   "serviceEndpoint": "https://example.com/endpoint",
-                   "type": "DIDCommMessaging"
+                   "id": "#service",
+                    "type": "DIDCommMessaging",
+                    "serviceEndpoint": {
+                        "uri": "https://example.com/endpoint"
+                    }
                }
            ]
        }

--- a/didpeer/src/commonTest/kotlin/io/iohk/atala/prism/didcomm/didpeer/TestCreateNumalgo2.kt
+++ b/didpeer/src/commonTest/kotlin/io/iohk/atala/prism/didcomm/didpeer/TestCreateNumalgo2.kt
@@ -168,6 +168,45 @@ class TestCreateNumalgo2 {
     }
 
     @Test
+    fun testCreateNumalgo2PositiveServicesIndividuallyEncoded() {
+        for (keys in validKeys) {
+            val service = """[
+            {
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": { 
+                    "uri" : "https://example.com/endpoint",
+                    "routingKeys": ["did:example:somemediator#somekey"]
+                }    
+            },
+            {
+                "type": "example",
+                "serviceEndpoint": { 
+                    "uri" : "https://example.com/endpoint2",
+                    "routingKeys": ["did:example:somemediator#somekey2"],
+                    "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+                }
+            }
+            ]
+            """
+
+            val peerDIDAlgo2 = createPeerDIDNumalgo2(
+                encryptionKeys = keys.encKeys,
+                signingKeys = keys.signingKeys,
+                service = service
+            )
+            assertEquals(
+                "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc" +
+                    ".Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V" +
+                    ".Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg" +
+                    ".SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19fQ" +
+                    ".SeyJ0IjoiZXhhbXBsZSIsInMiOnsidXJpIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfX0",
+                peerDIDAlgo2
+            )
+            assertTrue(isPeerDID(peerDIDAlgo2))
+        }
+    }
+
+    @Test
     fun testCreateNumalgo2PositiveServiceNotArray() {
         val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)
         val signingKeys = listOf(VALID_ED25519_KEY_1_MULTIBASE, VALID_ED25519_KEY_2_MULTIBASE)
@@ -186,6 +225,30 @@ class TestCreateNumalgo2 {
                 signingKeys = signingKeys,
                 service = service
             )
+
+        assertTrue(isPeerDID(peerDIDAlgo2))
+    }
+
+    @Test
+    fun testCreateNumalgo2PositiveServiceNotArrayWithServiceEndpointAsJson() {
+        val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)
+        val signingKeys = listOf(VALID_ED25519_KEY_1_MULTIBASE, VALID_ED25519_KEY_2_MULTIBASE)
+        val service =
+            """
+            {
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": {
+                "uri": "https://example.com/endpoint",
+                "routingKeys": ["did:example:somemediator#somekey"]
+                }
+            }
+            """
+
+        val peerDIDAlgo2 = createPeerDIDNumalgo2(
+            encryptionKeys = encryptionKeys,
+            signingKeys = signingKeys,
+            service = service
+        )
 
         assertTrue(isPeerDID(peerDIDAlgo2))
     }
@@ -214,6 +277,30 @@ class TestCreateNumalgo2 {
     }
 
     @Test
+    fun testCreateNumalgo2PositiveServiceMinimalFieldsWithServiceEndpointAsJson() {
+        val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)
+        val signingKeys = listOf(VALID_ED25519_KEY_1_MULTIBASE, VALID_ED25519_KEY_2_MULTIBASE)
+
+        val service =
+            """
+            {
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": { 
+                    "uri": "https://example.com/endpoint"
+                }
+            }
+            """
+
+        val peerDIDAlgo2 = createPeerDIDNumalgo2(
+            encryptionKeys = encryptionKeys,
+            signingKeys = signingKeys,
+            service = service
+        )
+
+        assertTrue(isPeerDID(peerDIDAlgo2))
+    }
+
+    @Test
     fun testCreateNumalgo2PositiveServiceArrayOf1Element() {
         val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)
         val signingKeys = listOf(VALID_ED25519_KEY_1_MULTIBASE, VALID_ED25519_KEY_2_MULTIBASE)
@@ -234,6 +321,110 @@ class TestCreateNumalgo2 {
                 signingKeys = signingKeys,
                 service = service
             )
+
+        assertTrue(isPeerDID(peerDIDAlgo2))
+    }
+
+    @Test
+    fun testCreateNumalgo2PositiveServiceArrayOf1ElementWithServiceEndpointAsJson() {
+        val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)
+        val signingKeys = listOf(VALID_ED25519_KEY_1_MULTIBASE, VALID_ED25519_KEY_2_MULTIBASE)
+
+        val service = """
+        [
+            {
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": {
+                    "uri": "https://example.com/endpoint",
+                    "routingKeys": ["did:example:somemediator#somekey"]
+                }
+            }    
+        ]
+        """
+
+        val peerDIDAlgo2 = createPeerDIDNumalgo2(
+            encryptionKeys = encryptionKeys,
+            signingKeys = signingKeys,
+            service = service
+        )
+
+        assertTrue(isPeerDID(peerDIDAlgo2))
+    }
+
+    /**
+     * @see <a href="https://identity.foundation/peer-did-method-spec/#method-2-multiple-inception-key-without-doc">Docs</a>
+     */
+    @Test
+    fun testCreateNumalgo2PositiveServiceArrayOf1ElementUsingNewPeerDidSpec() {
+        val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)
+        val signingKeys = listOf(VALID_ED25519_KEY_1_MULTIBASE, VALID_ED25519_KEY_2_MULTIBASE)
+
+        val service = """
+        [
+          {
+          "type": "DIDCommMessaging",
+          "serviceEndpoint": {
+            "uri": "http://example.com/didcomm",
+            "accept": [
+              "didcomm/v2"
+            ],
+            "routingKeys": [
+              "did:example:123456789abcdefghi#key-1"
+            ]
+          }
+          }    
+        ]
+        """
+
+        val peerDIDAlgo2 = createPeerDIDNumalgo2(
+            encryptionKeys = encryptionKeys,
+            signingKeys = signingKeys,
+            service = service
+        )
+
+        assertTrue(isPeerDID(peerDIDAlgo2))
+    }
+
+    /**
+     * <a href="https://identity.foundation/peer-did-method-spec/#method-2-multiple-inception-key-without-doc">Docs</a>
+     */
+    @Test
+    fun testCreateNumalgo2PositiveServiceArrayOfMoreThen1ElementUsingNewPeerDidSpec() {
+        val encryptionKeys = listOf(VALID_X25519_KEY_MULTIBASE)
+        val signingKeys = listOf(VALID_ED25519_KEY_1_MULTIBASE, VALID_ED25519_KEY_2_MULTIBASE)
+
+        val service = """
+        [
+          {
+          "type": "DIDCommMessaging",
+          "serviceEndpoint": {
+            "uri": "http://example.com/didcomm",
+            "accept": [
+              "didcomm/v2"
+            ],
+            "routingKeys": [
+              "did:example:123456789abcdefghi#key-1"
+            ]
+          }
+          },
+          {
+          "type": "example",
+          "serviceEndpoint": {
+            "uri": "http://example.com/didcomm",
+            "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"],
+            "routingKeys": [
+              "did:example:123456789abcdefghi#key-2"
+            ]
+          }
+          }    
+        ]
+        """
+
+        val peerDIDAlgo2 = createPeerDIDNumalgo2(
+            encryptionKeys = encryptionKeys,
+            signingKeys = signingKeys,
+            service = service
+        )
 
         assertTrue(isPeerDID(peerDIDAlgo2))
     }

--- a/didpeer/src/commonTest/kotlin/io/iohk/atala/prism/didcomm/didpeer/TestDIDDocFromJson.kt
+++ b/didpeer/src/commonTest/kotlin/io/iohk/atala/prism/didcomm/didpeer/TestDIDDocFromJson.kt
@@ -105,20 +105,19 @@ class TestDIDDocFromJson {
             val expectedService = (fromJson(testData.didDoc)["service"] as List<Map<String, Any>>)[0]
             assertTrue(service is DIDCommServicePeerDID)
             assertEquals((expectedService["id"] as JsonPrimitive).content, service.id)
-            assertEquals((expectedService["serviceEndpoint"] as JsonPrimitive).content, service.serviceEndpoint)
             assertEquals((expectedService["type"] as JsonPrimitive).content, service.type)
 
-            val expectedServiceRoutingKeys =
-                (expectedService["routingKeys"] as JsonArray).map {
-                    it.jsonPrimitive.content
-                }
-            assertEquals(expectedServiceRoutingKeys, service.routingKeys)
-
-            val expectedServiceAccept =
-                (expectedService["accept"] as JsonArray).map {
-                    it.jsonPrimitive.content
-                }
-            assertEquals(expectedServiceAccept, service.accept)
+            val expectedServiceEndpoint = expectedService["serviceEndpoint"] as Map<String, Any>
+            val expectedUri = (expectedServiceEndpoint["uri"] as JsonElement).jsonPrimitive.content
+            assertEquals(expectedUri, service.serviceEndpoint.uri)
+            val expectedRoutingKeys = (expectedServiceEndpoint["routingKeys"] as JsonArray).map {
+                it.jsonPrimitive.content
+            }
+            assertEquals(expectedRoutingKeys, service.serviceEndpoint.routingKeys)
+            val expectedAccept = (expectedServiceEndpoint["accept"] as JsonArray).map {
+                it.jsonPrimitive.content
+            }
+            assertEquals(expectedAccept, service.serviceEndpoint.accept)
 
             assertEquals(
                 listOf(
@@ -148,15 +147,15 @@ class TestDIDDocFromJson {
         assertEquals(
             (expectedService1["id"] as JsonElement).jsonPrimitive.content,
             service1.id
-        ) // (expectedService1["id"] as JsonElement).jsonPrimitive.content
-        assertEquals((expectedService1["serviceEndpoint"] as JsonElement).jsonPrimitive.content, service1.serviceEndpoint)
+        )
         assertEquals((expectedService1["type"] as JsonElement).jsonPrimitive.content, service1.type)
-        val expectedService1RoutingKeys =
-            (expectedService1["routingKeys"] as JsonArray).map {
-                it.jsonPrimitive.content
-            }
-        assertEquals(expectedService1RoutingKeys, service1.routingKeys)
-        assertTrue(service1.accept.isEmpty())
+        val expectedServiceEndpoint1 = expectedService1["serviceEndpoint"] as Map<String, Any>
+        assertEquals((expectedServiceEndpoint1["uri"] as JsonElement).jsonPrimitive.content, service1.serviceEndpoint.uri)
+        val expectedRoutingKeys: List<String> = (expectedServiceEndpoint1["routingKeys"] as JsonArray).map {
+            it.jsonPrimitive.content
+        }
+        assertEquals(expectedRoutingKeys, service1.serviceEndpoint.routingKeys)
+        assertTrue(service1.serviceEndpoint.accept.isEmpty())
 
         val service2 = didDoc.service!![1]
         val expectedService2 =
@@ -184,14 +183,11 @@ class TestDIDDocFromJson {
 
         val service = didDoc.service!![0]
         assertTrue(service is DIDCommServicePeerDID)
-        assertEquals(
-            "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9#didcommmessaging-0",
-            service.id
-        )
-        assertEquals("https://example.com/endpoint", service.serviceEndpoint)
+        assertEquals("#service", service.id)
+        assertEquals("https://example.com/endpoint", service.serviceEndpoint.uri)
         assertEquals("DIDCommMessaging", service.type)
-        assertTrue(service.routingKeys.isEmpty())
-        assertTrue(service.accept.isEmpty())
+        assertTrue(service.serviceEndpoint.routingKeys.isEmpty())
+        assertTrue(service.serviceEndpoint.accept.isEmpty())
     }
 
     @Test

--- a/didpeer/src/commonTest/kotlin/io/iohk/atala/prism/didcomm/didpeer/TestDemo.kt
+++ b/didpeer/src/commonTest/kotlin/io/iohk/atala/prism/didcomm/didpeer/TestDemo.kt
@@ -56,4 +56,65 @@ class TestDemo {
         println("==================================")
         print("DIDDoc algo 2:${didDocAlgo2.toDict()}")
     }
+
+    /**
+     * @see <a href="https://identity.foundation/peer-did-method-spec/">Docs</a>
+     */
+    @Test
+    fun testCreateResolvePeerDIDWithNewPeerDidSpec() {
+        val encryptionKeys = listOf(
+            VerificationMaterialAgreement(
+                type = VerificationMethodTypeAgreement.X25519KeyAgreementKey2019,
+                format = VerificationMaterialFormatPeerDID.BASE58,
+                value = "DmgBSHMqaZiYqwNMEJJuxWzsGGC8jUYADrfSdBrC6L8s"
+            )
+        )
+        val signingKeys = listOf(
+            VerificationMaterialAuthentication(
+                type = VerificationMethodTypeAuthentication.ED25519VerificationKey2018,
+                format = VerificationMaterialFormatPeerDID.BASE58,
+                value = "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
+            )
+        )
+        val service =
+            """
+                {
+                  "type": "DIDCommMessaging",
+                  "serviceEndpoint": {
+                    "uri": "https://example.com/endpoint1",
+                    "routingKeys": [
+                      "did:example:somemediator#somekey1"
+                    ],
+                    "accept": [
+                      "didcomm/v2",
+                      "didcomm/aip2;env=rfc587"
+                    ]
+                  }
+                }
+            """
+
+        val peerDIDAlgo0 = createPeerDIDNumalgo0(signingKeys[0])
+        val peerDIDAlgo2 = createPeerDIDNumalgo2(
+            encryptionKeys,
+            signingKeys,
+            service
+        )
+
+        println("PeerDID algo 0:$peerDIDAlgo0")
+        println("==================================")
+        println("PeerDID algo 2:$peerDIDAlgo2")
+        println("==================================")
+
+        val didDocAlgo0Json = resolvePeerDID(peerDIDAlgo0)
+        val didDocAlgo2Json = resolvePeerDID(peerDIDAlgo2)
+        println("DIDDoc algo 0:$didDocAlgo0Json")
+        println("==================================")
+        print("DIDDoc algo 2:$didDocAlgo2Json")
+
+        val didDocAlgo0 = DIDDocPeerDID.fromJson(didDocAlgo0Json)
+        val didDocAlgo2 = DIDDocPeerDID.fromJson(didDocAlgo2Json)
+        println("DIDDoc algo 0:${didDocAlgo0.toDict()}")
+        println("==================================")
+        print("DIDDoc algo 2:${didDocAlgo2.toDict()}")
+    }
 }

--- a/didpeer/src/commonTest/kotlin/io/iohk/atala/prism/didcomm/didpeer/core/TestServiceEncodeDecode.kt
+++ b/didpeer/src/commonTest/kotlin/io/iohk/atala/prism/didcomm/didpeer/core/TestServiceEncodeDecode.kt
@@ -29,11 +29,13 @@ class TestServiceEncodeDecode {
             listOf(
                 OtherService(
                     mapOf(
-                        "id" to "$PEER_DID_NUMALGO_2#didcommmessaging-0",
+                        "id" to "#service",
                         "type" to "DIDCommMessaging",
-                        "serviceEndpoint" to "https://example.com/endpoint",
-                        "routingKeys" to listOf("did:example:somemediator#somekey"),
-                        "accept" to listOf("didcomm/v2", "didcomm/aip2;env=rfc587")
+                        "serviceEndpoint" to mapOf(
+                            "uri" to "https://example.com/endpoint",
+                            "routingKeys" to listOf("did:example:somemediator#somekey"),
+                            "accept" to listOf("didcomm/v2", "didcomm/aip2;env=rfc587")
+                        )
                     )
                 )
             )
@@ -45,6 +47,29 @@ class TestServiceEncodeDecode {
                 PEER_DID_NUMALGO_2
             )
         assertEquals(expected, service)
+    }
+
+    @Test
+    fun testEncodeServiceEndpointFields() {
+        assertEquals(
+            ".SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHA6Ly9leGFtcGxlLmNvbS9kaWRjb21tIiwiYSI6WyJkaWRjb21tL3YyIl0sInIiOlsiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2tleS0xIl19fQ",
+            encodeService(
+                """
+                        {
+                          "type": "DIDCommMessaging",
+                          "serviceEndpoint": {
+                            "uri": "http://example.com/didcomm",
+                            "accept": [
+                              "didcomm/v2"
+                            ],
+                            "routingKeys": [
+                              "did:example:123456789abcdefghi#key-1"
+                            ]
+                          }
+                        }
+                        """
+            )
+        )
     }
 
     @Test
@@ -68,9 +93,11 @@ class TestServiceEncodeDecode {
             listOf(
                 OtherService(
                     mapOf(
-                        "id" to "$PEER_DID_NUMALGO_2#didcommmessaging-0",
+                        "id" to "#service",
                         "type" to "DIDCommMessaging",
-                        "serviceEndpoint" to "https://example.com/endpoint"
+                        "serviceEndpoint" to mapOf(
+                            "uri" to "https://example.com/endpoint"
+                        )
                     )
                 )
             )
@@ -114,19 +141,23 @@ class TestServiceEncodeDecode {
             listOf(
                 OtherService(
                     mapOf(
-                        "id" to "$PEER_DID_NUMALGO_2#didcommmessaging-0",
+                        "id" to "#service",
                         "type" to "DIDCommMessaging",
-                        "serviceEndpoint" to "https://example.com/endpoint",
-                        "routingKeys" to listOf("did:example:somemediator#somekey"),
-                        "accept" to listOf("didcomm/v2", "didcomm/aip2;env=rfc587")
+                        "serviceEndpoint" to mapOf(
+                            "uri" to "https://example.com/endpoint",
+                            "routingKeys" to listOf("did:example:somemediator#somekey"),
+                            "accept" to listOf("didcomm/v2", "didcomm/aip2;env=rfc587")
+                        )
                     )
                 ),
                 OtherService(
                     mapOf(
-                        "id" to "$PEER_DID_NUMALGO_2#didcommmessaging-1",
+                        "id" to "#service-1",
                         "type" to "DIDCommMessaging",
-                        "serviceEndpoint" to "https://example.com/endpoint2",
-                        "routingKeys" to listOf("did:example:somemediator#somekey2")
+                        "serviceEndpoint" to mapOf(
+                            "uri" to "https://example.com/endpoint2",
+                            "routingKeys" to listOf("did:example:somemediator#somekey2")
+                        )
                     )
                 )
             )
@@ -145,19 +176,23 @@ class TestServiceEncodeDecode {
         val expected = listOf(
             OtherService(
                 mapOf(
-                    "id" to "$PEER_DID_NUMALGO_2#didcommmessaging-0",
+                    "id" to "#service",
                     "type" to "DIDCommMessaging",
-                    "serviceEndpoint" to "https://example.com/endpoint",
-                    "routingKeys" to listOf("did:example:somemediator#somekey"),
-                    "accept" to listOf("didcomm/v2", "didcomm/aip2;env=rfc587")
+                    "serviceEndpoint" to mapOf(
+                        "uri" to "https://example.com/endpoint",
+                        "routingKeys" to listOf("did:example:somemediator#somekey"),
+                        "accept" to listOf("didcomm/v2", "didcomm/aip2;env=rfc587")
+                    )
                 )
             ),
             OtherService(
                 mapOf(
-                    "id" to "$PEER_DID_NUMALGO_2#didcommmessaging-1",
+                    "id" to "#service-1",
                     "type" to "DIDCommMessaging",
-                    "serviceEndpoint" to "https://example.com/endpoint2",
-                    "routingKeys" to listOf("did:example:somemediator#somekey2")
+                    "serviceEndpoint" to mapOf(
+                        "uri" to "https://example.com/endpoint2",
+                        "routingKeys" to listOf("did:example:somemediator#somekey2")
+                    )
                 )
             )
         )


### PR DESCRIPTION
# Overview
https://identity.foundation/peer-did-method-spec

This PR updates the library to align with the latest specifications for creating and resolving peer DIDs. It ensures compatibility with current and new methods of specifying the service field in a peer DID.

The PR accommodates two formats for defining the service field in the peer DID creation process. The first format is as follows:
```json
{
	"type": "DIDCommMessaging",
	"serviceEndpoint": "https://example.com/endpoint1",
	"routingKeys": ["did:example:somemediator#somekey1"],
	"accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
}
```
Using this format, a peer DID similar to the one below is created:
```
did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDEiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MSJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfQ
```

The second format, as per the new peer DID spec, is as follows:
```json
{
  "type": "DIDCommMessaging",
  "serviceEndpoint": {
    "uri": "https://example.com/endpoint1",
    "routingKeys": [
      "did:example:somemediator#somekey1"
    ],
    "accept": [
      "didcomm/v2",
      "didcomm/aip2;env=rfc587"
    ]
  }
}
```

This results in a peer DID like this:

```
did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19
```

In both cases, the resolution of the peer DID will conform to the new peer DID specification, producing a resolved DID document similar to the following:

```json
{
  "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
  "authentication": [
    {
      "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19#key-2",
      "type": "Ed25519VerificationKey2020",
      "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
      "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
    }
  ],
  "keyAgreement": [
    {
      "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19#key-1",
      "type": "X25519KeyAgreementKey2020",
      "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SeyJ0IjoiZG0iLCJzIjp7InVyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQxIiwiciI6WyJkaWQ6ZXhhbXBsZTpzb21lbWVkaWF0b3Ijc29tZWtleTEiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX19",
      "publicKeyMultibase": "z6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud"
    }
  ],
  "service": [
    {
      "id": "#service",
      "type": "DIDCommMessaging",
      "serviceEndpoint": {
        "uri": "https://example.com/endpoint1",
        "routingKeys": [
          "did:example:somemediator#somekey1"
        ],
        "accept": [
          "didcomm/v2",
          "didcomm/aip2;env=rfc587"
        ]
      }
    }
  ]
}
```

Tests have been added and updated to support both described cases, ensuring that the peer DID creation and resolution process aligns with the new peer DID specification.

Fixes #<issue number>

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [x] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [x] My changes require a change to the project documentation
* [x] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [x] My changes can and should be tested by unit and/or integration tests
* [x] If yes to above: I have added tests to cover my changes
* [x] If yes to above: I have taken care to cover edge cases in my tests