### PR TITLE
fix: remove id from diddoc service encoding

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 1.1.0
+version = 1.1.1
 #Gradle
 org.gradle.jvmargs = -Xmx3072M -Dkotlin.daemon.jvm.options="-Xmx3072M"
 #Kotlin


### PR DESCRIPTION
# Overview
This pr fixes did peer creation for the new specification. With @goncalo-frade-iohk's help, we found an issue on the diddoc service encoding logic where the ID was included when it shouldn't.
This is fixed now.

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [X] Bug fixes (non-breaking change which fixes an issue)
* [] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [X] My changes do not require a change to the project documentation
* [] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [X] My changes can and should be tested by unit and/or integration tests
* [X] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests